### PR TITLE
Reworked ctrl + f

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,4 +1,4 @@
-import { handleSearchInput, searchSchedules, generateList } from './modules/utils.js';
+import { handleSearchInput, searchSchedules, generateList, checkCtrlF } from './modules/utils.js';
 
 document.addEventListener('DOMContentLoaded', async function()
 {
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', async function()
 
     document.addEventListener('keydown', function(event)
     {
-        if (event.ctrlKey && event.key === 'f')
+        if (checkCtrlF(event))
         {
             event.preventDefault();
             search_input.focus();

--- a/js/index.js
+++ b/js/index.js
@@ -1,4 +1,4 @@
-import { handleSearchInput, searchSchedules, generateList, checkCtrlF } from './modules/utils.js';
+import { handleSearchInput, searchSchedules, generateList, checkCtrlD, handleCtrlD } from './modules/utils.js';
 
 document.addEventListener('DOMContentLoaded', async function()
 {
@@ -10,12 +10,8 @@ document.addEventListener('DOMContentLoaded', async function()
 
     document.addEventListener('keydown', function(event)
     {
-        if (checkCtrlF(event))
-        {
-            event.preventDefault();
-            search_input.focus();
-            search_input.select();
-        }
+        if (checkCtrlD(event))
+            handleCtrlD(event, search_input);
     });
 
     search_button.addEventListener('click', searchSchedules);

--- a/js/modules/utils.js
+++ b/js/modules/utils.js
@@ -167,3 +167,20 @@ export async function generateList(listType)
         anchor.textContent = spanTexts[i];
     }
 }
+
+export function checkCtrlF(event)
+{
+    if ((event.ctrlKey || event.metaKey) && event.key === 'f')
+        return true;
+
+    return false;
+}
+
+export function handleCtrlF(event, search_input, svg=null, navContainer=null, scheduleIframe=null, showNav=null)
+{
+    event.preventDefault();
+    if (showNav)
+        showNav(svg, navContainer, scheduleIframe);
+    search_input.focus();
+    search_input.select();
+}

--- a/js/modules/utils.js
+++ b/js/modules/utils.js
@@ -168,15 +168,15 @@ export async function generateList(listType)
     }
 }
 
-export function checkCtrlF(event)
+export function checkCtrlD(event)
 {
-    if ((event.ctrlKey || event.metaKey) && event.key === 'f')
+    if ((event.ctrlKey || event.metaKey) && event.key === 'd')
         return true;
 
     return false;
 }
 
-export function handleCtrlF(event, search_input, svg=null, navContainer=null, scheduleIframe=null, showNav=null)
+export function handleCtrlD(event, search_input, svg=null, navContainer=null, scheduleIframe=null, showNav=null)
 {
     event.preventDefault();
     if (showNav)

--- a/js/plan_index.js
+++ b/js/plan_index.js
@@ -1,4 +1,4 @@
-import { handleSearchInput, generateList, handleCtrlF, checkCtrlF } from './modules/utils.js';
+import { handleSearchInput, generateList, handleCtrlD, checkCtrlD } from './modules/utils.js';
 
 let search_input;
 let wasOverThreshold = window.innerWidth > 980;
@@ -18,14 +18,13 @@ document.addEventListener('DOMContentLoaded', async function()
     if (scheduleHref)
         scheduleIframe.src = scheduleHref;
 
-
     search_input = document.getElementById('search-input');
     window.addEventListener('message', function(event)
     {
         if (event.data.msg_type.startsWith('Plan'))
             scheduleTitle.textContent = event.data.msg_type;
-        else if (event.data.msg_type === 'ctrlF')
-            handleCtrlF(event, search_input, svg, navContainer, scheduleIframe, showNav);
+        else if (event.data.msg_type === 'ctrlD')
+            handleCtrlD(event, search_input, svg, navContainer, scheduleIframe, showNav);
         else if (event.data.msg_type === 'kumiGaming')
             window.location.href = event.data.href;
     });
@@ -58,8 +57,8 @@ document.addEventListener('DOMContentLoaded', async function()
 
     document.addEventListener('keydown', function(event)
     {
-        if (checkCtrlF(event))
-            handleCtrlF(event, search_input, svg, navContainer, scheduleIframe, showNav);
+        if (checkCtrlD(event))
+            handleCtrlD(event, search_input, svg, navContainer, scheduleIframe, showNav);
     });
 
     //Schowanie nav bara, jeśli jest widoczny, po zmniejszeniu okna przeglądarki

--- a/js/plan_index.js
+++ b/js/plan_index.js
@@ -1,4 +1,4 @@
-import { handleSearchInput, generateList } from './modules/utils.js';
+import { handleSearchInput, generateList, handleCtrlF, checkCtrlF } from './modules/utils.js';
 
 let search_input;
 let wasOverThreshold = window.innerWidth > 980;
@@ -18,12 +18,14 @@ document.addEventListener('DOMContentLoaded', async function()
     if (scheduleHref)
         scheduleIframe.src = scheduleHref;
 
+
+    search_input = document.getElementById('search-input');
     window.addEventListener('message', function(event)
     {
         if (event.data.msg_type.startsWith('Plan'))
             scheduleTitle.textContent = event.data.msg_type;
         else if (event.data.msg_type === 'ctrlF')
-            handleCtrlF(event, svg, navContainer, scheduleIframe);
+            handleCtrlF(event, search_input, svg, navContainer, scheduleIframe, showNav);
         else if (event.data.msg_type === 'kumiGaming')
             window.location.href = event.data.href;
     });
@@ -56,8 +58,8 @@ document.addEventListener('DOMContentLoaded', async function()
 
     document.addEventListener('keydown', function(event)
     {
-        if (event.ctrlKey && event.key === 'f')
-            handleCtrlF(event, svg, navContainer, scheduleIframe);
+        if (checkCtrlF(event))
+            handleCtrlF(event, search_input, svg, navContainer, scheduleIframe, showNav);
     });
 
     //Schowanie nav bara, jeśli jest widoczny, po zmniejszeniu okna przeglądarki
@@ -66,7 +68,6 @@ document.addEventListener('DOMContentLoaded', async function()
     window.addEventListener('resize', () => handleMediaQuery(svg, navContainer, scheduleIframe));
 
     //Obsługa wyszukiwarki
-    search_input = document.getElementById('search-input');
     let container = document.getElementById('container');
 
     search_input.addEventListener('keyup', () => handleSearchInput(container, search_input));
@@ -113,12 +114,4 @@ function handleMediaQuery(svg, navContainer, scheduleIframe)
         showNav(svg, navContainer, scheduleIframe);
 
     wasOverThreshold = isOverThreshold;
-}
-
-function handleCtrlF(event, svg, navContainer, scheduleIframe) 
-{
-   event.preventDefault();
-   showNav(svg, navContainer, scheduleIframe);
-   search_input.focus();
-   search_input.select();
 }

--- a/js/plan_script.js
+++ b/js/plan_script.js
@@ -1,9 +1,11 @@
+import { checkCtrlF } from './modules/utils.js';
+
 document.addEventListener('DOMContentLoaded', function()
 {
     let title = document.querySelector('title');
     document.addEventListener('keydown', function(event) 
     {
-        if (event.ctrlKey && event.key === 'f') 
+        if (checkCtrlF(event))
         {
             event.preventDefault();
             window.parent.postMessage({msg_type: 'ctrlF'}, '*');

--- a/js/plan_script.js
+++ b/js/plan_script.js
@@ -1,14 +1,14 @@
-import { checkCtrlF } from './modules/utils.js';
+import { checkCtrlD } from './modules/utils.js';
 
 document.addEventListener('DOMContentLoaded', function()
 {
     let title = document.querySelector('title');
     document.addEventListener('keydown', function(event) 
     {
-        if (checkCtrlF(event))
+        if (checkCtrlD(event))
         {
             event.preventDefault();
-            window.parent.postMessage({msg_type: 'ctrlF'}, '*');
+            window.parent.postMessage({msg_type: 'ctrlD'}, '*');
         }
     });
 


### PR DESCRIPTION
This pull request introduces a new keyboard shortcut (Ctrl+D) to the codebase to retain original Ctrl+F functionality built-in browsers. The changes are spread across multiple files, with the main focus on handling the new shortcut and updating the event listeners accordingly.

### Introduction of Ctrl+D shortcut and refactoring:

* [`js/index.js`](diffhunk://#diff-3f689a613b62130589affae189bdfbcff8533286dcf50c288ccf61bd9b59c11cL1-R1): Added `checkCtrlD` and `handleCtrlD` functions to the imports and updated the event listener to use `checkCtrlD` and `handleCtrlD` instead of the hardcoded Ctrl+F logic. [[1]](diffhunk://#diff-3f689a613b62130589affae189bdfbcff8533286dcf50c288ccf61bd9b59c11cL1-R1) [[2]](diffhunk://#diff-3f689a613b62130589affae189bdfbcff8533286dcf50c288ccf61bd9b59c11cL13-R14)
* [`js/modules/utils.js`](diffhunk://#diff-8de07e4f23ce36c9b5ba1268c6e32cc658f789a5ee5748f69224211bf3dd34a4R170-R186): Added new functions `checkCtrlD` and `handleCtrlD` to handle the Ctrl+D shortcut logic.
* [`js/plan_index.js`](diffhunk://#diff-f834b5cbaf441b0f68b7ca95397339ce49aeb4bdf27265d4107045d44b3c8230L1-R1): Updated imports to include `checkCtrlD` and `handleCtrlD`, and refactored the event listeners to use these functions. Removed the old `handleCtrlF` function. [[1]](diffhunk://#diff-f834b5cbaf441b0f68b7ca95397339ce49aeb4bdf27265d4107045d44b3c8230L1-R1) [[2]](diffhunk://#diff-f834b5cbaf441b0f68b7ca95397339ce49aeb4bdf27265d4107045d44b3c8230R21-R27) [[3]](diffhunk://#diff-f834b5cbaf441b0f68b7ca95397339ce49aeb4bdf27265d4107045d44b3c8230L59-R61) [[4]](diffhunk://#diff-f834b5cbaf441b0f68b7ca95397339ce49aeb4bdf27265d4107045d44b3c8230L69) [[5]](diffhunk://#diff-f834b5cbaf441b0f68b7ca95397339ce49aeb4bdf27265d4107045d44b3c8230L117-L124)
* [`js/plan_script.js`](diffhunk://#diff-df27d1a69909ab5c8bfacbdcf62844a056b7d17c4756bec7330df67dd6c41b1fR1-R11): Added `checkCtrlD` function to the imports and updated the event listener to use `checkCtrlD` and post a message with `msg_type: 'ctrlD'`.