### PR TITLE
nerfed minors, fixed box shadow on twitch embed, added border radius and cleaned up some css

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -25,7 +25,7 @@ body
     background-size: cover;
     background-attachment: fixed;
     color: #EEEEEE;
-    font-family: "Kanit";
+    font-family: "Kanit", sans-serif;
     &::-webkit-scrollbar
     {
         width: 8px;
@@ -127,9 +127,9 @@ section#lists > div:not(div.in-between) > h3
 }
 div.in-between
 {
-    margin: 0px;
-    padding: 0px;
-    width: 0px;
+    margin: 0;
+    padding: 0;
+    width: 0;
     border: 1px solid #76ABAE;
     height: auto;
 }

--- a/css/plan.css
+++ b/css/plan.css
@@ -16,6 +16,7 @@
         background-color: #85a2a4;  
     }
 }
+
 body 
 {
     margin: 0;
@@ -42,6 +43,7 @@ body
         min-width: max-content;
     }
 }
+
 html
 {
     overflow: scroll;
@@ -66,6 +68,7 @@ html
         display: none;
     }
 }
+
 table 
 {
     background-color: #31363F;
@@ -156,10 +159,16 @@ div#twitch-embed
     display: flex;
     justify-content: center;
 
-    &:focus
+    & *
     {
-        outline: none;
+        box-shadow: none;
+        border-radius: 3%;
     }
+    @media(hover: hover)
+    {
+        margin-left: 5px;
+    }
+
 }
 
 /*

--- a/css/plan_index.css
+++ b/css/plan_index.css
@@ -2,7 +2,7 @@
 
 * 
 {
-    font-family: 'Kanit';
+    font-family: 'Kanit', sans-serif;
     color: #EEEEEE;
 
     &:focus 
@@ -16,6 +16,7 @@
         background-color: #556b6c;  
     }
 }
+
 body 
 {
     display: flex;
@@ -246,7 +247,7 @@ svg#arrow
         border-radius: 0;
         font-size: 3.5em;
         position: relative;
-        left: 0%;
+        left: 0;
         padding-bottom: 120px;
 
         @media (hover: hover) 
@@ -272,7 +273,7 @@ svg#arrow
     }
     div#container
     {
-        padding: 0px 10px;
+        padding: 0 10px;
         width: calc(100% - 20px);
     }
     div#search-field-container
@@ -310,8 +311,7 @@ svg#arrow
         border-radius: 0 0 30% 30%;
         background-color: #31363F;
         fill: #76ABAE;
-        z-index: 100;
-    
+
         @media (hover: hover)
         {
             width: 3em;

--- a/js/modules/utils.js
+++ b/js/modules/utils.js
@@ -18,7 +18,7 @@ function getDisplayName(filename)
     return filename.replace(/\s[A-Z]+\.html$/, '');
 }
 
-function addElement(elementToAdd, targetElement)
+export function addElement(elementToAdd, targetElement)
 {
     let element = document.createElement(elementToAdd);
     targetElement.appendChild(element);

--- a/js/plan_script.js
+++ b/js/plan_script.js
@@ -1,4 +1,4 @@
-import { checkCtrlD } from './modules/utils.js';
+import { checkCtrlD, addElement } from './modules/utils.js';
 
 document.addEventListener('DOMContentLoaded', function()
 {
@@ -12,31 +12,33 @@ document.addEventListener('DOMContentLoaded', function()
         }
     });
 
-    if (document.querySelector('a#kumi_gaming') !== null)
-    {
-        document.querySelector('a#kumi_gaming').addEventListener('click', function(event)
-        {
-            event.preventDefault();
-            document.body.innerHTML = '';
-            let embed = document.createElement('div');
-            embed.id = 'twitch-embed';
-            document.body.appendChild(embed);
-
-            let script = document.createElement('script');
-            script.src = 'https://embed.twitch.tv/embed/v1.js';
-            script.onload = function() {
-                new Twitch.Embed('twitch-embed', {
-                    width: '100%',
-                    height: '100%',
-                    channel: 'Kumi_Gaming',
-                    parent: [window.location.hostname]
-                });
-            };
-            document.body.appendChild(script);
-        });
-    }
+    let kumi_gaming_anchor = document.querySelector('a#kumi_gaming');
+    if (kumi_gaming_anchor !== null)
+        kumi_gaming_anchor.addEventListener('click', createTwitchEmbed);
 
     //Wysyłanie title strony do parenta (plan_index) i ustawienie widoczności strony
     document.body.style.visibility = 'visible';
     window.parent.postMessage({msg_type: title.textContent.trim()}, '*');
 });
+
+function createTwitchEmbed(event)
+{
+    event.preventDefault();
+    document.body.innerHTML = '';
+    let embed = addElement('div', document.body);
+    embed.id = 'twitch-embed';
+
+    let script = addElement('script', document.body);
+    script.src = 'https://embed.twitch.tv/embed/v1.js';
+
+    script.onload = function()
+    {
+        new Twitch.Embed('twitch-embed',
+            {
+                width: '100%',
+                height: '100%',
+                channel: 'Kumi_Gaming',
+                parent: [window.location.hostname]
+            });
+    };
+}


### PR DESCRIPTION
This pull request includes updates to several CSS files to improve consistency and code quality, and a JavaScript refactor to modularize and streamline the code. The most important changes include adding a fallback font, standardizing CSS property values, and refactoring JavaScript functions for better maintainability.

### CSS Improvements:

* [`css/index.css`](diffhunk://#diff-da08da0da5bfd24f80d8d86681fca579c0cbdc9f64bbe06251878d7762815cceL28-R28): Added a fallback font `sans-serif` to the `font-family` property in the `body` selector.
* [`css/index.css`](diffhunk://#diff-da08da0da5bfd24f80d8d86681fca579c0cbdc9f64bbe06251878d7762815cceL130-R132): Standardized the values for `margin`, `padding`, and `width` properties in the `div.in-between` selector.
* [`css/plan_index.css`](diffhunk://#diff-1e79d7abec96ee1d470f4b22d6709a7f2d559116e70c1a186b7c1e8a39d35822L5-R5): Added a fallback font `sans-serif` to the `font-family` property in the global selector.
* [`css/plan_index.css`](diffhunk://#diff-1e79d7abec96ee1d470f4b22d6709a7f2d559116e70c1a186b7c1e8a39d35822L249-R250): Standardized the `left` and `padding` properties in the `svg#arrow` and `div#container` selectors. [[1]](diffhunk://#diff-1e79d7abec96ee1d470f4b22d6709a7f2d559116e70c1a186b7c1e8a39d35822L249-R250) [[2]](diffhunk://#diff-1e79d7abec96ee1d470f4b22d6709a7f2d559116e70c1a186b7c1e8a39d35822L275-R276)

### JavaScript Refactor:

* [`js/modules/utils.js`](diffhunk://#diff-8de07e4f23ce36c9b5ba1268c6e32cc658f789a5ee5748f69224211bf3dd34a4L21-R21): Exported the `addElement` function to make it reusable across different modules.
* [`js/plan_script.js`](diffhunk://#diff-df27d1a69909ab5c8bfacbdcf62844a056b7d17c4756bec7330df67dd6c41b1fL1-R1): Imported the `addElement` function from `utils.js` and refactored the `createTwitchEmbed` function to use this utility for creating elements. [[1]](diffhunk://#diff-df27d1a69909ab5c8bfacbdcf62844a056b7d17c4756bec7330df67dd6c41b1fL1-R1) [[2]](diffhunk://#diff-df27d1a69909ab5c8bfacbdcf62844a056b7d17c4756bec7330df67dd6c41b1fL15-L42)