### PR TITLE
added info about shortcuts

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
             <section id="container">
                 <div id="searching-container">
                     <div id="search-field-container">
-                        <input type="text" id="search-input" placeholder="Szukaj planu" autocomplete="off" aria-label="Szukaj planu">
+                        <input type="text" id="search-input" placeholder="Szukaj planu (Ctrl + D)" autocomplete="off" aria-label="Szukaj planu">
                         <svg id="search-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#888888" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                             <circle cx="11" cy="11" r="8"></circle>
                             <line x1="21" y1="21" x2="16.65" y2="16.65"></line>

--- a/plan_index.html
+++ b/plan_index.html
@@ -19,7 +19,7 @@
         <a href="../planyzsk/index.html">Strona główna</a>
         <div id="container">
             <div id="search-field-container">
-                <input type="text" id="search-input" placeholder="Szukaj planu" autocomplete="off" aria-label="Szukaj planu">
+                <input type="text" id="search-input" placeholder="Szukaj planu (Ctrl + D)" autocomplete="off" aria-label="Szukaj planu">
                 <svg id="search-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#888888" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <circle cx="11" cy="11" r="8"></circle>
                     <line x1="21" y1="21" x2="16.65" y2="16.65"></line>


### PR DESCRIPTION
This pull request includes minor changes to the search input placeholder text in both `index.html` and `plan_index.html` files to provide a keyboard shortcut hint.

Changes to placeholder text:

* [`index.html`](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L29-R29): Updated the search input placeholder to include "(Ctrl + D)" for better user guidance.
* [`plan_index.html`](diffhunk://#diff-dde1e904b701147b377bb2f18f72a6ea672b4ede10a073e8c9552eeb983edee9L22-R22): Updated the search input placeholder to include "(Ctrl + D)" for consistency with the main index page.